### PR TITLE
fix typo in docker image name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,4 +26,4 @@ How to run image?
 
 2. Run docker image::
 
-    docker run -it amrit3701/freecad-cli:lastest bash
+    docker run -it amrit3701/freecad-cli:latest bash


### PR DESCRIPTION
Hi Amritpal,

thanks a lot, very useful! Just found this small typo. The same typo is also on the wiki page.
Keep up the good work!

Cheers Alex.